### PR TITLE
Update kube-kubelet.service to remove --v=5

### DIFF
--- a/node/kube-kubelet.service
+++ b/node/kube-kubelet.service
@@ -6,7 +6,6 @@ After=calico-node.service
 [Service]
 EnvironmentFile=/etc/network-environment
 ExecStart=/usr/bin/kubelet \
---v=5 \
 --address=0.0.0.0 \
 --port=10250 \
 --hostname_override=${DEFAULT_IPV4} \


### PR DESCRIPTION
I know this isn't the end all be all configs to use in production. I ended up running these systemd files in dev/stage with a 8cpu/32gig k8 nodes with around 15 containers and 4 pods

the kubelet process was using 1.6gig of memory and 150% cpu. Also journelctl was using around 50-100% cpu which was causing load spikes from logging very verbose logging over to and EBS attached device. 

I'd either remove this or lower the logging level.
